### PR TITLE
Using ENTRYPOINT instead of CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ RUN apk add --no-cache --virtual .build-deps go git \
 
 VOLUME ["/etc/stns"]
 
-CMD ["stns"]
+ENTRYPOINT ["/bin/stns"]
 
 EXPOSE 1104


### PR DESCRIPTION
Using ENTRYPOINT, You can run `docker run stns/stns -conf /path/to/stns.conf` .
