### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-STNS Dockerfile [![Docker Pulls](https://img.shields.io/docker/pulls/stns/stns.svg?maxAge=2592000?style=flat-square)](https://hub.docker.com/r/stns/stns/)
+STNS Dockerfile [![Docker Pulls](https://img.shields.io/docker/pulls/stns/stns.svg?maxAge=2592000?style=flat-square)](https://hub.docker.com/r/stns/stns/) [![](https://images.microbadger.com/badges/image/stns/stns.svg)](https://microbadger.com/images/stns/stns "Get your own image badge on microbadger.com")
 ===
 
 Docker image for [STNS](https://github.com/STNS/STNS).
@@ -27,3 +27,4 @@ LICENSE
 ---
 
 https://hfm.mit-license.org/
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [stns/stns](https://hub.docker.com/r/stns/stns/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/stns/stns).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/stns/stns.svg)](https://microbadger.com/images/stns/stns)
