### PR TITLE
support 1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,15 @@
-FROM alpine:3.5
+FROM ubuntu:latest
 MAINTAINER OKUMURA Takahiro <hfm.garden@gmail.com>
 
-ENV STNS_VERSION v0.3-3
-
-RUN apk add --no-cache --virtual .build-deps go git musl-dev \
-      && GOPATH=/go go get github.com/STNS/STNS \
-      && cd /go/src/github.com/STNS/STNS \
-      && git checkout refs/tags/$STNS_VERSION \
-      && GOPATH=/go go build -v . \
-      && mv STNS /usr/bin/stns \
-      && apk del .build-deps \
-      && rm -rf /go
-
-COPY stns.conf /etc/stns/stns.conf
-
-VOLUME ["/etc/stns"]
-
+RUN apt-get update -qqy && \
+    apt-get install -qqy sudo curl gnupg && \
+    curl -fsSL https://repo.stns.jp/scripts/apt-repo.sh | sh && \
+    apt-get install -y stns-v2 libnss-stns-v2 && \
+    sed -i -e 's/^passwd:.*/passwd: files stns/g' /etc/nsswitch.conf && \
+        sed -i -e 's/^shadow:.*/shadow: files stns/g' /etc/nsswitch.conf && \
+        sed -i -e 's/^group:.*/group: files stns/g' /etc/nsswitch.conf
+COPY server.conf /etc/stns/server/stns.conf
+COPY client.conf /etc/stns/client/stns.conf
 CMD ["stns"]
 
 EXPOSE 1104

--- a/README.md
+++ b/README.md
@@ -9,13 +9,21 @@ Docker image for [STNS](https://github.com/STNS/STNS).
 
 ### Supported tags
 
-- `latest`, `0.3`, `0.3-0`, `0.3-1`, `0.3-2`, `0.3-3`
+- `latest`, `1.0.0`, `0.3`, `0.3-0`, `0.3-1`, `0.3-2`, `0.3-3`
 - `0.2`, `0.2-1`, `0.2-2`
 - `0.1`, `0.1-3`
 
+### Howto
+```bash
+# docker run -d --name stns stns:latest
+# docker exec -it stns /bin/bash
+$ id example
+$ /usr/local/lib/stns-key-wrapper example
+```
+
 ### Base docker Image
 
-- [alpine](https://hub.docker.com/_/alpine/)
+- [ubuntu](https://hub.docker.com/_/ubuntu/)
 
 What's STNS?
 ---

--- a/client.conf
+++ b/client.conf
@@ -1,0 +1,1 @@
+api_endpoint = "http://localhost:1104/v1"

--- a/server.conf
+++ b/server.conf
@@ -1,0 +1,10 @@
+port = 1104
+include = "/etc/stns/conf.d/*"
+
+[users.example]
+id = 2000
+group_id = 2000
+keys = ["example_keys"]
+
+[groups.example]
+id = 2000

--- a/stns.conf
+++ b/stns.conf
@@ -1,5 +1,0 @@
-port = 1104
-include = "/etc/stns/conf.d/*"
-salt_enable = true
-stretching_number = 100000
-hash_type = "sha256"


### PR DESCRIPTION
STNS v2のリリースにあたり、バージョンを1.0.0としました。また合わせて、雰囲気をつかみやすいようにlibnssも同梱するようにしました。